### PR TITLE
40 Checks tijdens het registeren

### DIFF
--- a/webshop/controller/loginController.php
+++ b/webshop/controller/loginController.php
@@ -71,7 +71,7 @@ class loginController
                 throw new inputException("email");
             } elseif ($this->checkPasswordValid($password) == false) { // Als password niet aan de eisen voldoet.
                 throw new inputException("password. Minimum 8 characters, at least one uppercase letter, one lowercase letter and one number");
-            } elseif ($this->checkDuplicateEmail($email) == true) {
+            } elseif ($this->checkDuplicateEmail($email) == true) { // Als emailadres al is geregistreerd.
                 throw new regularException("Your email has already been registered.");
             } else {
                 $this->data->signUpInsert($accountModel, $customerModel, $billingAddressModel, $shippingAddressModel);
@@ -83,6 +83,7 @@ class loginController
         }
     }
 
+    // Een methode om te kijken of een wachtwoord aan de volgende eisen voldoet: 8 karakters, 1 kleine letter en 1 hoofdletter.
     public function checkPasswordValid($password)
     {
         $regPassword = '/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}$/';
@@ -94,6 +95,7 @@ class loginController
         }
     }
 
+    // Een methode om te kijken of er een geldig emailadres is ingevuld.
     public function checkEmailValid($email)
     {
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -103,6 +105,7 @@ class loginController
         }
     }
 
+    // Een methode om de checkDuplicateEmailDB aan te roepen in de data file.
     public function checkDuplicateEmail($email)
     {
         return $this->data->checkDuplicateEmailDB($email);

--- a/webshop/controller/loginController.php
+++ b/webshop/controller/loginController.php
@@ -51,6 +51,60 @@ class loginController
     // Een methode om de signUpInsert functie in de data file op te roepen.
     public function SignUp($accountModel, $customerModel, $billingAddressModel, $shippingAddressModel)
     {
-        $this->data->signUpInsert($accountModel, $customerModel, $billingAddressModel, $shippingAddressModel);
+        $regNames = '/^[a-zA-Z\s]*$/'; // Regex bevat alleen letters en spaties.
+        $regNumbers = '/^[0-9]*$/'; // Regex bevat alleen cijfers
+
+        $firstname = $customerModel->getFirstName();
+        $lastname = $customerModel->getLastName();
+        $phonenumber = $customerModel->getPhoneNumber();
+        $email = $accountModel->getEmail();
+        $password = $accountModel->getPassword();
+
+        try {
+            if (preg_match("{$regNames}", "{$firstname}") == 0) { // Als firstname niet gelijk is aan de regex.
+                throw new inputException("first name");
+            } elseif (preg_match("{$regNames}", "{$lastname}") == 0) { // Als lastname niet gelijk is aan de regex.
+                throw new inputException("last name");
+            } elseif (preg_match("{$regNumbers}", "{$phonenumber}") == 0) { // Als phone number niet gelijk is aan de regex.
+                throw new inputException("phone number");
+            } elseif ($this->checkEmailValid($email) == false) { // Als email geen emailadres is.
+                throw new inputException("email");
+            } elseif ($this->checkPasswordValid($password) == false) { // Als password niet aan de eisen voldoet.
+                throw new inputException("password. Minimum 8 characters, at least one uppercase letter, one lowercase letter and one number");
+            } elseif ($this->checkDuplicateEmail($email) == true) {
+                throw new regularException("Your email has already been registered.");
+            } else {
+                $this->data->signUpInsert($accountModel, $customerModel, $billingAddressModel, $shippingAddressModel);
+            }
+        } catch (inputException $e) {
+            echo $e->getMessage();
+        } catch (regularException $e) {
+            echo $e->getMessage();
+        }
+    }
+
+    public function checkPasswordValid($password)
+    {
+        $regPassword = '/^(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[a-zA-Z]).{8,}$/';
+
+        if (preg_match("{$regPassword}", "{$password}") == 0) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public function checkEmailValid($email)
+    {
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+    public function checkDuplicateEmail($email)
+    {
+        return $this->data->checkDuplicateEmailDB($email);
     }
 }

--- a/webshop/data/exceptions.php
+++ b/webshop/data/exceptions.php
@@ -15,3 +15,19 @@ class loginException extends Exception
         echo "<div class='alert alert-danger'>Login error: {$message}</div>";
     }
 }
+
+class inputException extends Exception
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        echo "<div class='alert alert-danger'>Input error: invalid {$message}. Try again</div>";
+    }
+}
+
+class regularException extends Exception
+{
+    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    {
+        echo "<div class='alert alert-danger'>Error: {$message}</div>";
+    }
+}

--- a/webshop/data/loginData.php
+++ b/webshop/data/loginData.php
@@ -68,4 +68,20 @@ class loginData
             echo $e->getMessage();
         }
     }
+
+    public function checkDuplicateEmailDB($email)
+    {
+        $sql = "SELECT Email FROM `Accounts` WHERE Email ='{$email}' LIMIT 1;";
+        $stmt = $this->db->connect()->prepare($sql);
+        $stmt->execute();
+
+        $result = $stmt->fetchColumn();
+
+
+        if ($result) {
+            return true;
+        } else {
+            return false;
+        }
+    }
 }

--- a/webshop/data/loginData.php
+++ b/webshop/data/loginData.php
@@ -32,17 +32,24 @@ class loginData
     // Een methode om de gegevens van een model in de database op te slaan.
     public function signUpInsert($accountModel, $customerModel, $billingAddressModel, $shippingAddressModel)
     {
+        // Account
         $email = $accountModel->getEmail();
         $password = $accountModel->getPassword();
+
+        // Customer
         $customerNumber = $customerModel->getCustomerNumber();
         $firstName = $customerModel->getFirstName();
         $lastName = $customerModel->getLastName();
         $phoneNumber = $customerModel->getPhoneNumber();
+
+        // BillingAddress
         $baStreet = $billingAddressModel->getStreet();
         $baHouseNumber = $billingAddressModel->getHouseNumber();
         $baPostalCode = $billingAddressModel->getPostalCode();
         $baCity = $billingAddressModel->getCity();
         $baCountry = $billingAddressModel->getCountry();
+
+        // ShippingAddress
         $saStreet = $shippingAddressModel->getStreet();
         $saHouseNumber = $shippingAddressModel->getHouseNumber();
         $saPostalCode = $shippingAddressModel->getPostalCode();
@@ -69,6 +76,7 @@ class loginData
         }
     }
 
+    // Een methode om te kijken of het ingevoerde emailadres al in de database staat.
     public function checkDuplicateEmailDB($email)
     {
         $sql = "SELECT Email FROM `Accounts` WHERE Email ='{$email}' LIMIT 1;";

--- a/webshop/view/signup.php
+++ b/webshop/view/signup.php
@@ -29,7 +29,7 @@
 
             <tr>
                 <th>Phonenumber</th>
-                <td><input type="text" id="phonenumber" name="phonenumber" required></td>
+                <td><input type="text" id="phonenumber" name="phonenumber" placeholder="0612345678" required></td>
             </tr>
 
             <tr>


### PR DESCRIPTION
Wanneer een gebruiker zich registreerd worden de volgende checks uitgevoerd:
- De voornaam bevat alleen maar letters en spaties.
- De achternaam bevat alleen maar letters en spaties.
- Het telefoonnummer bevat alleen maar cijfers.
- Voldoet het wachtwoord aan de  volgende eisen: 8 karakters, 1 kleine letter en 1 hoofdletter.
- Is het ingevoerde emailadres daadwerkelijk een emailadres?
- Bestaat het ingevoerde emailadres al in de database?

Als er een fout is op 1 van deze checks word na het indienen van het formulier een foutmelding verstuurd en kan de gebruiker zijn gegevens wijzigen.

Fix #40 